### PR TITLE
removes deprecated Arr::getValue method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
   - composer install --dev --no-interaction

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ composer require starlit/utils
 ```
 
 ## Requirements
-- Requires PHP 5.6 or above.
+- Requires PHP 7.1 or above.
 
 ## License
 This software is licensed under the BSD 3-Clause License - see the `LICENSE` file for details.

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
       "psr-4": {"Starlit\\Utils\\": "src"}

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -207,18 +207,4 @@ class Arr
 
         return $sortedArray;
     }
-
-    /**
-     * @param array  $array
-     * @param string $key
-     * @param mixed  $default
-     * @return mixed
-     *
-     * @deprecated  will be removed in v1.0.0 which requires php7.1 or later and
-     *              thus can be replaced by using the null coalescing operator
-     */
-    public static function getValue(array $array, $key, $default = null)
-    {
-        return isset($array[$key]) ? $array[$key] : $default;
-    }
 }

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -2,7 +2,9 @@
 
 namespace Starlit\Utils;
 
-class ArrTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ArrTest extends TestCase
 {
     public function testAnyIn()
     {
@@ -14,7 +16,7 @@ class ArrTest extends \PHPUnit_Framework_TestCase
     public function testAnyInIsFalse()
     {
         $array = [1, 2, 3];
-        $this->assertFalse(Arr::anyIn([4 ,5 ,6], $array));
+        $this->assertFalse(Arr::anyIn([4, 5, 6], $array));
         $this->assertFalse(Arr::anyIn(6, $array));
     }
 
@@ -139,16 +141,16 @@ class ArrTest extends \PHPUnit_Framework_TestCase
             3 => '1',
         ];
         $arrayObjects = [
-            1 => (object) ['id' => 1],
-            3 => (object) ['id' => 3],
-            4 => (object) ['id' => 4],
-            5 => (object) ['id' => 5]
+            1 => (object)['id' => 1],
+            3 => (object)['id' => 3],
+            4 => (object)['id' => 4],
+            5 => (object)['id' => 5]
         ];
         $desiredArray = [
-            0 => (object) ['id' => 4],
-            1 => (object) ['id' => 3],
-            2 => (object) ['id' => 5],
-            3 => (object) ['id' => 1]
+            0 => (object)['id' => 4],
+            1 => (object)['id' => 3],
+            2 => (object)['id' => 5],
+            3 => (object)['id' => 1]
         ];
 
         // Sort the array
@@ -156,18 +158,6 @@ class ArrTest extends \PHPUnit_Framework_TestCase
 
         // It should be sorted correctly
         $this->assertEquals($desiredArray, $sortedArray);
-    }
-
-    public function testGetValue()
-    {
-        $testArray = ['key' => 'value'];
-        $this->assertEquals('value', Arr::getValue($testArray, 'key'));
-    }
-
-    public function testGetValueDefault()
-    {
-        $testArray = ['key' => 'value'];
-        $this->assertEquals('default', Arr::getValue($testArray, 'nonExistingKey', 'default'));
     }
 }
 

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -90,8 +90,8 @@ class ArrTest extends TestCase
     {
         $testArray = ['1', 'a'];
         $resultArray = Arr::valuesWithType($testArray, 'int');
-        $this->assertInternalType('int', $resultArray[0]);
-        $this->assertInternalType('int', $resultArray[1]);
+        $this->assertIsInt($resultArray[0]);
+        $this->assertIsInt($resultArray[1]);
     }
 
     public function testGetArrayValuesWithInvalidType()
@@ -141,16 +141,16 @@ class ArrTest extends TestCase
             3 => '1',
         ];
         $arrayObjects = [
-            1 => (object)['id' => 1],
-            3 => (object)['id' => 3],
-            4 => (object)['id' => 4],
-            5 => (object)['id' => 5]
+            1 => (object) ['id' => 1],
+            3 => (object) ['id' => 3],
+            4 => (object) ['id' => 4],
+            5 => (object) ['id' => 5]
         ];
         $desiredArray = [
-            0 => (object)['id' => 4],
-            1 => (object)['id' => 3],
-            2 => (object)['id' => 5],
-            3 => (object)['id' => 1]
+            0 => (object) ['id' => 4],
+            1 => (object) ['id' => 3],
+            2 => (object) ['id' => 5],
+            3 => (object) ['id' => 1]
         ];
 
         // Sort the array

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -2,7 +2,9 @@
 
 namespace Starlit\Utils;
 
-class StrTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class StrTest extends TestCase
 {
 
     public function testSeparatorToCamelCase()

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -2,7 +2,9 @@
 
 namespace Starlit\Utils;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class UrlTest extends TestCase
 {
     /**
      * @var Url


### PR DESCRIPTION
As suggested by @felixsand before this PR removes the deprecated `Arr::getValue` function in favour of the [Null Coalescing Operator](https://secure.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.coalesce).

This PR
* removes the `Arr:getValue` method
* raises the php requirement to 7.1. 
* update the package `phpunit/phpunit` to a version constraint `^7.5`